### PR TITLE
✨ feature wasm module hot reloading

### DIFF
--- a/capsule-launcher/services/http/httpfiber.go
+++ b/capsule-launcher/services/http/httpfiber.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+//import json "github.com/goccy/go-json"
+
 type RemoteWasmModule struct {
 	Url  string `json:"url"`
 	Path string `json:"path"`
@@ -38,7 +40,11 @@ func FiberServe(httpPort string, wasmFileModule []byte, crt, key string) {
 	//+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 	app := fiber.New(fiber.Config{
 		DisableStartupMessage: true,
+		//DisableKeepalive:      true,
+		//Concurrency:           100000,
 	})
+
+	//app.Use(requestid.New())
 
 	// host-metrics
 	app.Get("/host-metrics", func(c *fiber.Ctx) error {
@@ -96,6 +102,8 @@ func FiberServe(httpPort string, wasmFileModule []byte, crt, key string) {
 
 	app.Post("/", func(c *fiber.Ctx) error {
 		jsonStr := string(c.Body())
+
+		//fmt.Println("🎃", c.GetReqHeaders())
 
 		headersStr := GetHeadersStringFromHeadersRequest(c)
 		uri := c.Request().URI().String()

--- a/capsule-launcher/services/http/requestfiber.go
+++ b/capsule-launcher/services/http/requestfiber.go
@@ -1,6 +1,7 @@
 package capsulehttp
 
 import (
+	"fmt"
 	"github.com/bots-garden/capsule/commons"
 	"github.com/gofiber/fiber/v2"
 )
@@ -15,4 +16,13 @@ func GetHeadersStringFromHeadersRequest(c *fiber.Ctx) string {
 	headersParameter := commons.CreateStringFromSlice(headersSlice, commons.StrSeparator)
 
 	return headersParameter
+}
+
+func GetReloadTokenFromHeadersRequest(c *fiber.Ctx) string {
+	/*
+	   Fiber canonicalizes the header name when adding values to the header map.
+	   ex: `CAPSULE_RELOAD_TOKEN` becomes `Capsule_reload_token`
+	*/
+	fmt.Println(c.GetReqHeaders())
+	return c.GetReqHeaders()["Capsule_reload_token"]
 }

--- a/capsule-launcher/services/wasmrt/wasmfile.go
+++ b/capsule-launcher/services/wasmrt/wasmfile.go
@@ -1,0 +1,62 @@
+package capsule
+
+import (
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	"os"
+)
+
+/*
+## Remote loading of the wasm module
+
+```bash
+capsule \
+   -url=http://localhost:9090/hello.wasm \
+   -wasm=./tmp/hello.wasm \
+   -mode=http \
+   -httpPort=8080
+```
+- url flag: the download url
+- wasm flag: the path where to save the wasm file
+
+### Serve with python:
+
+```bash
+python3 -m http.server 9090
+```
+
+Now you can download the wasm file with this url:
+http://localhost:9090/hello.wasm
+
+*/
+
+func loadWasmFile(path string) ([]byte, error) {
+	wasmFileToLoad, errLoadWasmFile := os.ReadFile(path)
+
+	if errLoadWasmFile != nil {
+		fmt.Println("🔴 Error while loading the wasm file:", errLoadWasmFile)
+		//os.Exit(1)
+	}
+	return wasmFileToLoad, errLoadWasmFile
+}
+
+func GetWasmFileFromUrl(wasmFileUrl, wasmFilePath string) ([]byte, error) {
+
+	client := resty.New()
+	resp, errLoadWasmFileFromUrl := client.R().
+		SetOutput(wasmFilePath).
+		Get(wasmFileUrl)
+
+	if resp.IsError() {
+		fmt.Println("🔴 Error while downloading the wasm file:", "empty response")
+	}
+
+	if errLoadWasmFileFromUrl != nil {
+		fmt.Println("🔴 Error while downloading the wasm file:", errLoadWasmFileFromUrl)
+		return nil, errLoadWasmFileFromUrl
+	} else {
+		fmt.Println("🙂", "file downloaded", wasmFilePath)
+		return loadWasmFile(wasmFilePath)
+	}
+
+}

--- a/capsule-launcher/services/wasmrt/wasmrt.go
+++ b/capsule-launcher/services/wasmrt/wasmrt.go
@@ -1,13 +1,13 @@
 package capsule
 
 import (
-	"context"
-	"github.com/bots-garden/capsule/capsule-launcher/hostfunctions"
-	"log"
+    "context"
+    "github.com/bots-garden/capsule/capsule-launcher/hostfunctions"
+    "log"
 
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
-	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+    "github.com/tetratelabs/wazero"
+    "github.com/tetratelabs/wazero/api"
+    "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 // GetPackedPtrPositionAndSize :
@@ -15,71 +15,71 @@ import (
 //ex: the string pointer position (in memory) and the length of the string
 
 func GetPackedPtrPositionAndSize(result []uint64) (ptrPos uint32, size uint32) {
-	return uint32(result[0] >> 32), uint32(result[0])
+    return uint32(result[0] >> 32), uint32(result[0])
 }
 
 func CreateWasmRuntime(ctx context.Context) wazero.Runtime {
 
-	wasmRuntime := wazero.NewRuntime(ctx)
-	//https://github.com/tetratelabs/wazero/blob/main/examples/allocation/tinygo/greet.go#L29
+    wasmRuntime := wazero.NewRuntime(ctx)
+    //https://github.com/tetratelabs/wazero/blob/main/examples/allocation/tinygo/greet.go#L29
 
-	// 🏠 Add host functions to the wasmModule (to be availale from the module)
-	// These functions allows the module to call functions of the host
-	_, errEnv := wasmRuntime.NewHostModuleBuilder("env").
-		ExportFunction("hostLogString", hostfunctions.LogString).
-		ExportFunction("hostGetHostInformation", hostfunctions.GetHostInformation).
-		ExportFunction("hostPing", hostfunctions.Ping).
-		ExportFunction("hostHttp", hostfunctions.Http).
-		ExportFunction("hostReadFile", hostfunctions.ReadFile).
-		ExportFunction("hostWriteFile", hostfunctions.WriteFile).
-		ExportFunction("hostGetEnv", hostfunctions.GetEnv).
-		ExportFunction("hostRedisSet", hostfunctions.RedisSet).
-		ExportFunction("hostRedisGet", hostfunctions.RedisGet).
-		ExportFunction("hostRedisKeys", hostfunctions.RedisKeys).
-		ExportFunction("hostMemorySet", hostfunctions.MemorySet).
-		ExportFunction("hostMemoryGet", hostfunctions.MemoryGet).
-		ExportFunction("hostMemoryKeys", hostfunctions.MemoryKeys).
-		ExportFunction("hostCouchBaseQuery", hostfunctions.CouchBaseQuery).
-		ExportFunction("hostNatsPublish", hostfunctions.NatsPublish).
-		ExportFunction("hostNatsConnectPublish", hostfunctions.NatsConnectPublish).
-		ExportFunction("hostNatsGetSubject", hostfunctions.NatsGetSubject).
-		ExportFunction("hostNatsGetServer", hostfunctions.NatsGetServer).
-		ExportFunction("hostNatsConnectRequest", hostfunctions.NatsConnectRequest).
-		ExportFunction("hostNatsReply", hostfunctions.NatsReply).
-		ExportFunction("hostMqttGetTopic", hostfunctions.MqttGetTopic).
-		ExportFunction("hostMqttGetServer", hostfunctions.MqttGetServer).
-		ExportFunction("hostMqttGetClientId", hostfunctions.MqttGetClientId).
-		ExportFunction("hostMqttPublish", hostfunctions.MqttPublish).
-		ExportFunction("hostMqttConnectPublish", hostfunctions.MqttConnectPublish).
-		ExportFunction("hostGetExitError", hostfunctions.GetExitError).
-		ExportFunction("hostGetExitCode", hostfunctions.GetExitCode).
-		Instantiate(ctx, wasmRuntime)
+    // 🏠 Add host functions to the wasmModule (to be availale from the module)
+    // These functions allows the module to call functions of the host
+    _, errEnv := wasmRuntime.NewHostModuleBuilder("env").
+        ExportFunction("hostLogString", hostfunctions.LogString).
+        ExportFunction("hostGetHostInformation", hostfunctions.GetHostInformation).
+        ExportFunction("hostPing", hostfunctions.Ping).
+        ExportFunction("hostHttp", hostfunctions.Http).
+        ExportFunction("hostReadFile", hostfunctions.ReadFile).
+        ExportFunction("hostWriteFile", hostfunctions.WriteFile).
+        ExportFunction("hostGetEnv", hostfunctions.GetEnv).
+        ExportFunction("hostRedisSet", hostfunctions.RedisSet).
+        ExportFunction("hostRedisGet", hostfunctions.RedisGet).
+        ExportFunction("hostRedisKeys", hostfunctions.RedisKeys).
+        ExportFunction("hostMemorySet", hostfunctions.MemorySet).
+        ExportFunction("hostMemoryGet", hostfunctions.MemoryGet).
+        ExportFunction("hostMemoryKeys", hostfunctions.MemoryKeys).
+        ExportFunction("hostCouchBaseQuery", hostfunctions.CouchBaseQuery).
+        ExportFunction("hostNatsPublish", hostfunctions.NatsPublish).
+        ExportFunction("hostNatsConnectPublish", hostfunctions.NatsConnectPublish).
+        ExportFunction("hostNatsGetSubject", hostfunctions.NatsGetSubject).
+        ExportFunction("hostNatsGetServer", hostfunctions.NatsGetServer).
+        ExportFunction("hostNatsConnectRequest", hostfunctions.NatsConnectRequest).
+        ExportFunction("hostNatsReply", hostfunctions.NatsReply).
+        ExportFunction("hostMqttGetTopic", hostfunctions.MqttGetTopic).
+        ExportFunction("hostMqttGetServer", hostfunctions.MqttGetServer).
+        ExportFunction("hostMqttGetClientId", hostfunctions.MqttGetClientId).
+        ExportFunction("hostMqttPublish", hostfunctions.MqttPublish).
+        ExportFunction("hostMqttConnectPublish", hostfunctions.MqttConnectPublish).
+        ExportFunction("hostGetExitError", hostfunctions.GetExitError).
+        ExportFunction("hostGetExitCode", hostfunctions.GetExitCode).
+        Instantiate(ctx, wasmRuntime)
 
-	if errEnv != nil {
-		log.Panicln("🔴 Error with env module and host function(s):", errEnv)
-	}
+    if errEnv != nil {
+        log.Panicln("🔴 Error with env module and host function(s):", errEnv)
+    }
 
-	_, errInstantiate := wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
-	if errInstantiate != nil {
-		log.Panicln("🔴 Error with Instantiate:", errInstantiate)
-	}
+    _, errInstantiate := wasi_snapshot_preview1.Instantiate(ctx, wasmRuntime)
+    if errInstantiate != nil {
+        log.Panicln("🔴 Error with Instantiate:", errInstantiate)
+    }
 
-	return wasmRuntime
+    return wasmRuntime
 }
 
 func CreateWasmRuntimeAndModuleInstances(wasmFile []byte) (wazero.Runtime, api.Module, context.Context) {
-	// Choose the context to use for function calls.
-	ctx := context.Background()
+    // Choose the context to use for function calls.
+    ctx := context.Background()
 
-	wasmRuntime := CreateWasmRuntime(ctx)
-	//defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
+    wasmRuntime := CreateWasmRuntime(ctx)
+    //defer wasmRuntime.Close(ctx) // This closes everything this Runtime created.
 
-	// 🥚 Instantiate the wasm module (from the wasm file)
-	// 🖐 The main method is called at this moment
-	wasmModule, errInstanceWasmModule := wasmRuntime.InstantiateModuleFromBinary(ctx, wasmFile)
+    // 🥚 Instantiate the wasm module (from the wasm file)
+    // 🖐 The main method is called at this moment
+    wasmModule, errInstanceWasmModule := wasmRuntime.InstantiateModuleFromBinary(ctx, wasmFile)
 
-	if errInstanceWasmModule != nil {
-		log.Panicln("🔴 Error while creating module instance:", errInstanceWasmModule)
-	}
-	return wasmRuntime, wasmModule, ctx
+    if errInstanceWasmModule != nil {
+        log.Panicln("🔴 Error while creating module instance:", errInstanceWasmModule)
+    }
+    return wasmRuntime, wasmModule, ctx
 }

--- a/capsule-launcher/services/wasmrt/wasmrunner.go
+++ b/capsule-launcher/services/wasmrt/wasmrunner.go
@@ -1,140 +1,140 @@
 package capsule
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"github.com/tetratelabs/wazero"
-	"github.com/tetratelabs/wazero/api"
+    "context"
+    "errors"
+    "fmt"
+    "github.com/tetratelabs/wazero"
+    "github.com/tetratelabs/wazero/api"
 )
 
 func GetNewWasmRuntimeForHttp(wasmFile []byte) (runtime wazero.Runtime, module api.Module, function api.Function, context context.Context) {
-	//fmt.Println("🖐[checking] create new wasm runtime")
-	runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function = module.ExportedFunction("callHandleHttp")
-	return runtime, module, function, context
+    //fmt.Println("🖐[checking] create new wasm runtime")
+    runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function = module.ExportedFunction("callHandleHttp")
+    return runtime, module, function, context
 }
 
 func CallExportedOnLoad(wasmFile []byte) {
-	runtime, module, context := CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function := module.ExportedFunction("OnLoad")
+    runtime, module, context := CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function := module.ExportedFunction("OnLoad")
 
-	if function != nil {
-		//fmt.Println("🟢 Function founded")
-		defer runtime.Close(context)
+    if function != nil {
+        //fmt.Println("🟢 Function founded")
+        defer runtime.Close(context)
 
-		err := ExecVoidFunction(function, module, context)
-		if err != nil {
-			fmt.Println("🔴 Error", err.Error())
-		}
-	}
+        err := ExecVoidFunction(function, module, context)
+        if err != nil {
+            fmt.Println("🔴 Error", err.Error())
+        }
+    }
 
-	// QUESTION: should I return something ?
+    // QUESTION: should I return something ?
 }
 
 func CallExportedOnExit(wasmFile []byte) {
-	runtime, module, context := CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function := module.ExportedFunction("OnExit")
+    runtime, module, context := CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function := module.ExportedFunction("OnExit")
 
-	if function != nil {
-		//fmt.Println("🟢 Function founded")
-		defer runtime.Close(context)
+    if function != nil {
+        //fmt.Println("🟢 Function founded")
+        defer runtime.Close(context)
 
-		err := ExecVoidFunction(function, module, context)
-		if err != nil {
-			fmt.Println("🔴 Error", err.Error())
-		}
-	}
+        err := ExecVoidFunction(function, module, context)
+        if err != nil {
+            fmt.Println("🔴 Error", err.Error())
+        }
+    }
 
-	// QUESTION: should I return something ?
+    // QUESTION: should I return something ?
 }
 
 func GetNewWasmRuntime(wasmFile []byte) (runtime wazero.Runtime, module api.Module, function api.Function, context context.Context) {
-	runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function = module.ExportedFunction("callHandle")
-	return runtime, module, function, context
+    runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function = module.ExportedFunction("callHandle")
+    return runtime, module, function, context
 }
 
 func GetNewWasmRuntimeForNats(wasmFile []byte) (runtime wazero.Runtime, module api.Module, function api.Function, context context.Context) {
-	runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function = module.ExportedFunction("callNatsMessageHandle")
-	return runtime, module, function, context
+    runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function = module.ExportedFunction("callNatsMessageHandle")
+    return runtime, module, function, context
 }
 
 func GetNewWasmRuntimeForMqtt(wasmFile []byte) (runtime wazero.Runtime, module api.Module, function api.Function, context context.Context) {
-	runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
-	function = module.ExportedFunction("callMqttMessageHandle")
-	return runtime, module, function, context
+    runtime, module, context = CreateWasmRuntimeAndModuleInstances(wasmFile)
+    function = module.ExportedFunction("callMqttMessageHandle")
+    return runtime, module, function, context
 }
 
 // ReserveMemorySpaceFor :
 // Reserve a place for a string parameter in the wasm module shared memory
 func ReserveMemorySpaceFor(s string, wm api.Module, ctx context.Context) (pos uint64, length uint64, free api.Function, err error) {
-	length = uint64(len(s))
-	malloc := wm.ExportedFunction("malloc")
-	free = wm.ExportedFunction("free")
+    length = uint64(len(s))
+    malloc := wm.ExportedFunction("malloc")
+    free = wm.ExportedFunction("free")
 
-	results, err := malloc.Call(ctx, length)
-	if err != nil {
-		//log.Panicln("😡 out of bounds memory access", err)
-		return 0, 0, free, errors.New("😡 out of bounds memory access")
-	}
-	stringParameterPtrPosition := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	//defer free.Call(wr.Ctx, stringParameterPtrPosition)
+    results, err := malloc.Call(ctx, length)
+    if err != nil {
+        //log.Panicln("😡 out of bounds memory access", err)
+        return 0, 0, free, errors.New("😡 out of bounds memory access")
+    }
+    stringParameterPtrPosition := results[0]
+    // This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+    // So, we have to free it when finished
+    //defer free.Call(ctx, stringParameterPtrPosition)
 
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !wm.Memory().Write(ctx, uint32(stringParameterPtrPosition), []byte(s)) {
-		//log.Panicf("😡 Memory.Write(%d, %d) out of range of memory size %d", stringParameterPtrPosition, stringParameterLength, wr.Module.Memory().Size(wr.Ctx))
-		return 0, 0, free, errors.New("😡 Memory.Write out of range of memory size")
-	} else {
-		return stringParameterPtrPosition, length, free, nil
-	}
+    // The pointer is a linear memory offset, which is where we write the name.
+    if !wm.Memory().Write(ctx, uint32(stringParameterPtrPosition), []byte(s)) {
+        //log.Panicf("😡 Memory.Write(%d, %d) out of range of memory size %d", stringParameterPtrPosition, stringParameterLength, wr.Module.Memory().Size(wr.Ctx))
+        return 0, 0, free, errors.New("😡 Memory.Write out of range of memory size")
+    } else {
+        return stringParameterPtrPosition, length, free, nil
+    }
 }
 
 // ExecHandleFunction :
 // params: pos1, length1, pos2, length2, ...
 func ExecHandleFunction(function api.Function, module api.Module, ctx context.Context, params ...uint64) (bytes []byte, err error) {
-	// This shows how to
-	// read-back something allocated by TinyGo.
-	handleResultArray, err := function.Call(ctx, params...)
-	if err != nil {
-		//log.Panicln(err)
-		fmt.Println("😡[execHandleFunction]", err)
-		return nil, err
-	}
-	// Note: This pointer is still owned by TinyGo,
-	// so don't try to free it!
-	handleReturnPtrPos, handleReturnSize := GetPackedPtrPositionAndSize(handleResultArray)
+    // This shows how to
+    // read-back something allocated by TinyGo.
+    handleResultArray, err := function.Call(ctx, params...)
+    if err != nil {
+        //log.Panicln(err)
+        fmt.Println("😡[execHandleFunction]", err)
+        return nil, err
+    }
+    // Note: This pointer is still owned by TinyGo,
+    // so don't try to free it!
+    handleReturnPtrPos, handleReturnSize := GetPackedPtrPositionAndSize(handleResultArray)
 
-	// The pointer is a linear memory offset,
-	// which is where we write the name.
-	bytes, ok := module.Memory().Read(ctx, handleReturnPtrPos, handleReturnSize)
-	if !ok {
-		return nil, errors.New("😡[execHandleFunction] Memory.Read out of range of memory size")
-	}
-	return bytes, nil
+    // The pointer is a linear memory offset,
+    // which is where we write the name.
+    bytes, ok := module.Memory().Read(ctx, handleReturnPtrPos, handleReturnSize)
+    if !ok {
+        return nil, errors.New("😡[execHandleFunction] Memory.Read out of range of memory size")
+    }
+    return bytes, nil
 }
 
 // ExecVoidFunction :
 func ExecVoidFunction(function api.Function, module api.Module, ctx context.Context) (err error) {
-	_, err = function.Call(ctx)
-	if err != nil {
-		fmt.Println("😡[execVoidFunction]", err)
-	}
-	return err
+    _, err = function.Call(ctx)
+    if err != nil {
+        fmt.Println("😡[execVoidFunction]", err)
+    }
+    return err
 }
 
 // ExecHandleVoidFunction :
 // params: pos1, length1, pos2, length2, ...
 func ExecHandleVoidFunction(function api.Function, module api.Module, ctx context.Context, params ...uint64) (err error) {
-	// This shows how to
-	// read-back something allocated by TinyGo.
-	_, err = function.Call(ctx, params...)
-	if err != nil {
-		fmt.Println("😡[execHandleVoidFunction]", err)
+    // This shows how to
+    // read-back something allocated by TinyGo.
+    _, err = function.Call(ctx, params...)
+    if err != nil {
+        fmt.Println("😡[execHandleVoidFunction]", err)
 
-	}
-	return err
+    }
+    return err
 }

--- a/wasm_modules/capsule-hello-post/hello.go
+++ b/wasm_modules/capsule-hello-post/hello.go
@@ -2,52 +2,55 @@ package main
 
 // TinyGo wasm module
 import (
-	hf "github.com/bots-garden/capsule/capsulemodule/hostfunctions"
-	/* string to json */
-	"github.com/tidwall/gjson"
-	/* create json string */
-	"github.com/tidwall/sjson"
+    hf "github.com/bots-garden/capsule/capsulemodule/hostfunctions"
+    /* string to json */
+    "github.com/tidwall/gjson"
+    /* create json string */
+    "github.com/tidwall/sjson"
 )
 
 // main is required.
 func main() {
 
-	hf.SetHandleHttp(Handle)
+    hf.SetHandleHttp(Handle)
 }
 
 func Handle(request hf.Request) (response hf.Response, errResp error) {
-	/*
-	   bodyReq = {"author":"Philippe","message":"Golang 💚 wasm"}
-	*/
-	hf.Log("📝 Body: " + request.Body)
-	hf.Log("📝 URI: " + request.Uri)
-	hf.Log("📝 Method: " + request.Method)
+    /*
+       bodyReq = {"author":"Philippe","message":"Golang 💚 wasm"}
+    */
+    capsuleVersion, _ := hf.MemoryGet("capsule_version")
+    hf.Log("🖐 Version: " + capsuleVersion)
 
-	author := gjson.Get(request.Body, "author")
-	message := gjson.Get(request.Body, "message")
-	hf.Log("👋 " + message.String() + " by " + author.String() + " 😄")
+    hf.Log("📝 Body: " + request.Body)
+    hf.Log("📝 URI: " + request.Uri)
+    hf.Log("📝 Method: " + request.Method)
 
-	hf.Log("Content-Type: " + request.Headers["Content-Type"])
-	hf.Log("Content-Length: " + request.Headers["Content-Length"])
-	hf.Log("User-Agent: " + request.Headers["User-Agent"])
+    author := gjson.Get(request.Body, "author")
+    message := gjson.Get(request.Body, "message")
+    hf.Log("👋 " + message.String() + " by " + author.String() + " 😄")
 
-	envMessage, err := hf.GetEnv("MESSAGE")
-	if err != nil {
-		hf.Log("😡 " + err.Error())
-	} else {
-		hf.Log("Environment variable: " + envMessage)
-	}
+    hf.Log("Content-Type: " + request.Headers["Content-Type"])
+    hf.Log("Content-Length: " + request.Headers["Content-Length"])
+    hf.Log("User-Agent: " + request.Headers["User-Agent"])
 
-	headersResp := map[string]string{
-		"Content-Type": "application/json; charset=utf-8",
-		"Message":      "👋 hello world 🌍",
-	}
+    envMessage, err := hf.GetEnv("MESSAGE")
+    if err != nil {
+        hf.Log("😡 " + err.Error())
+    } else {
+        hf.Log("Environment variable: " + envMessage)
+    }
 
-	jsondoc := `{"message": "", "author": ""}`
-	jsondoc, _ = sjson.Set(jsondoc, "message", "👋 hey! What's up?")
-	jsondoc, _ = sjson.Set(jsondoc, "author", "Bob")
+    headersResp := map[string]string{
+        "Content-Type": "application/json; charset=utf-8",
+        "Message":      "👋 hello world 🌍",
+    }
 
-	return hf.Response{Body: jsondoc, Headers: headersResp}, err
+    jsondoc := `{"message": "", "author": ""}`
+    jsondoc, _ = sjson.Set(jsondoc, "message", "👋 hey! What's up?")
+    jsondoc, _ = sjson.Set(jsondoc, "author", "Bob")
+
+    return hf.Response{Body: jsondoc, Headers: headersResp}, err
 }
 
 /*

--- a/wasm_modules/hot-reload/hello-one/.gitignore
+++ b/wasm_modules/hot-reload/hello-one/.gitignore
@@ -1,0 +1,1 @@
+capsule

--- a/wasm_modules/hot-reload/hello-one/build.sh
+++ b/wasm_modules/hot-reload/hello-one/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+go mod tidy
+tinygo build -o hello-one.wasm -scheduler=none -target wasi ./hello.go
+
+ls -lh *.wasm

--- a/wasm_modules/hot-reload/hello-one/go.mod
+++ b/wasm_modules/hot-reload/hello-one/go.mod
@@ -1,0 +1,19 @@
+module hello-one
+
+go 1.18
+
+replace github.com/bots-garden/capsule/capsulemodule => ../../../capsulemodule
+
+replace github.com/bots-garden/capsule/commons => ../../../commons
+
+require (
+	github.com/bots-garden/capsule/capsulemodule v0.2.8
+	github.com/tidwall/sjson v1.2.5
+)
+
+require (
+	github.com/bots-garden/capsule/commons v0.2.8 // indirect
+	github.com/tidwall/gjson v1.14.3 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+)

--- a/wasm_modules/hot-reload/hello-one/go.sum
+++ b/wasm_modules/hot-reload/hello-one/go.sum
@@ -1,0 +1,10 @@
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=

--- a/wasm_modules/hot-reload/hello-one/hello.go
+++ b/wasm_modules/hot-reload/hello-one/hello.go
@@ -1,0 +1,31 @@
+package main
+
+// TinyGo wasm module
+import (
+    hf "github.com/bots-garden/capsule/capsulemodule/hostfunctions"
+
+    /* create json string */
+    "github.com/tidwall/sjson"
+)
+
+// main is required.
+func main() {
+
+    hf.SetHandleHttp(Handle)
+}
+
+func Handle(request hf.Request) (response hf.Response, errResp error) {
+
+    headersResp := map[string]string{
+        "Content-Type": "application/json; charset=utf-8",
+    }
+
+    jsondoc := `{"message": ""}`
+    jsondoc, _ = sjson.Set(jsondoc, "message", "👋 hey! What's up?")
+
+    return hf.Response{Body: jsondoc, Headers: headersResp}, nil
+}
+
+/*
+curl http://localhost:7070
+*/

--- a/wasm_modules/hot-reload/hello-one/refresh_package.sh
+++ b/wasm_modules/hot-reload/hello-one/refresh_package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+go get -u ./...
+
+

--- a/wasm_modules/hot-reload/hello-two/.gitignore
+++ b/wasm_modules/hot-reload/hello-two/.gitignore
@@ -1,0 +1,1 @@
+capsule

--- a/wasm_modules/hot-reload/hello-two/build.sh
+++ b/wasm_modules/hot-reload/hello-two/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+go mod tidy
+tinygo build -o hello-two.wasm -scheduler=none -target wasi ./hello.go
+
+ls -lh *.wasm

--- a/wasm_modules/hot-reload/hello-two/go.mod
+++ b/wasm_modules/hot-reload/hello-two/go.mod
@@ -1,0 +1,19 @@
+module hello-two
+
+go 1.18
+
+replace github.com/bots-garden/capsule/capsulemodule => ../../../capsulemodule
+
+replace github.com/bots-garden/capsule/commons => ../../../commons
+
+require (
+	github.com/bots-garden/capsule/capsulemodule v0.2.8
+	github.com/tidwall/sjson v1.2.5
+)
+
+require (
+	github.com/bots-garden/capsule/commons v0.2.8 // indirect
+	github.com/tidwall/gjson v1.14.3 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+)

--- a/wasm_modules/hot-reload/hello-two/go.sum
+++ b/wasm_modules/hot-reload/hello-two/go.sum
@@ -1,0 +1,10 @@
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=

--- a/wasm_modules/hot-reload/hello-two/hello.go
+++ b/wasm_modules/hot-reload/hello-two/hello.go
@@ -1,0 +1,31 @@
+package main
+
+// TinyGo wasm module
+import (
+	hf "github.com/bots-garden/capsule/capsulemodule/hostfunctions"
+
+	/* create json string */
+	"github.com/tidwall/sjson"
+)
+
+// main is required.
+func main() {
+
+	hf.SetHandleHttp(Handle)
+}
+
+func Handle(request hf.Request) (response hf.Response, errResp error) {
+
+	headersResp := map[string]string{
+		"Content-Type": "application/json; charset=utf-8",
+	}
+
+	jsondoc := `{"message": ""}`
+	jsondoc, _ = sjson.Set(jsondoc, "message", "👋 hello world 🌍")
+
+	return hf.Response{Body: jsondoc, Headers: headersResp}, nil
+}
+
+/*
+curl http://localhost:7070
+*/

--- a/wasm_modules/hot-reload/hello-two/refresh_package.sh
+++ b/wasm_modules/hot-reload/hello-two/refresh_package.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+go get -u ./...
+
+

--- a/wasm_modules/hot-reload/query.sh
+++ b/wasm_modules/hot-reload/query.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+curl http://localhost:7070
+echo ""

--- a/wasm_modules/hot-reload/re-load-module-one.sh
+++ b/wasm_modules/hot-reload/re-load-module-one.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+curl -v -X POST \
+  http://localhost:7070/load-wasm-module \
+  -H 'content-type: application/json; charset=utf-8' \
+  -d '{"url": "http://localhost:9090/hello-one/hello-one.wasm", "path": "./tmp/hello-one.wasm"}'
+echo ""

--- a/wasm_modules/hot-reload/re-load-module-one.sh
+++ b/wasm_modules/hot-reload/re-load-module-one.sh
@@ -2,5 +2,6 @@
 curl -v -X POST \
   http://localhost:7070/load-wasm-module \
   -H 'content-type: application/json; charset=utf-8' \
+  -H 'CAPSULE_RELOAD_TOKEN: ilovepandas' \
   -d '{"url": "http://localhost:9090/hello-one/hello-one.wasm", "path": "./tmp/hello-one.wasm"}'
 echo ""

--- a/wasm_modules/hot-reload/re-load-module-two.sh
+++ b/wasm_modules/hot-reload/re-load-module-two.sh
@@ -2,5 +2,6 @@
 curl -v -X POST \
   http://localhost:7070/load-wasm-module \
   -H 'content-type: application/json; charset=utf-8' \
+  -H 'CAPSULE_RELOAD_TOKEN: ilovepandas' \
   -d '{"url": "http://localhost:9090/hello-two/hello-two.wasm", "path": "./tmp/hello-two.wasm"}'
 echo ""

--- a/wasm_modules/hot-reload/re-load-module-two.sh
+++ b/wasm_modules/hot-reload/re-load-module-two.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+curl -v -X POST \
+  http://localhost:7070/load-wasm-module \
+  -H 'content-type: application/json; charset=utf-8' \
+  -d '{"url": "http://localhost:9090/hello-two/hello-two.wasm", "path": "./tmp/hello-two.wasm"}'
+echo ""

--- a/wasm_modules/hot-reload/serve-wasm-files.sh
+++ b/wasm_modules/hot-reload/serve-wasm-files.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 -m http.server 9090

--- a/wasm_modules/hot-reload/start.sh
+++ b/wasm_modules/hot-reload/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd ../../capsule-launcher
-go run main.go \
+CAPSULE_RELOAD_TOKEN="ilovepandas" go run main.go \
    -url=http://localhost:9090/hello-one/hello-one.wasm \
    -wasm=./tmp/hello-one.wasm \
    -mode=http \

--- a/wasm_modules/hot-reload/start.sh
+++ b/wasm_modules/hot-reload/start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cd ../../capsule-launcher
+go run main.go \
+   -url=http://localhost:9090/hello-one/hello-one.wasm \
+   -wasm=./tmp/hello-one.wasm \
+   -mode=http \
+   -httpPort=7070

--- a/wasm_modules/hot-reload/tmp/.gitkeep.go
+++ b/wasm_modules/hot-reload/tmp/.gitkeep.go
@@ -1,0 +1,1 @@
+package tmp


### PR DESCRIPTION

I'm serving two wasm modules with: `python3 -m http.server 9090`

```bash
.
├── hello-one
│  └── hello-one.wasm
├── hello-two
│  └── hello-two.wasm
```

I start `hello-one.wasm` with:

```bash
capsule \
   -url=http://localhost:9090/hello-one/hello-one.wasm \
   -wasm=./tmp/hello-one.wasm \
   -mode=http \
   -httpPort=7070
```

I can call the function like this `curl http://localhost:7070`

And if I want to load a new version of the wasm module, I launch this request:

```bash
curl -v -X POST \
  http://localhost:7070/load-wasm-module \
  -H 'content-type: application/json; charset=utf-8' \
  -d '{"url": "http://localhost:9090/hello-two/hello-two.wasm", "path": "./tmp/hello-two.wasm"}'
```

I can call the new version of the function like this `curl http://localhost:7070`









