### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/capsule-launcher/go.mod
+++ b/capsule-launcher/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.39.0
 	github.com/google/uuid v1.3.0
 	github.com/nats-io/nats.go v1.18.0
-	github.com/tetratelabs/wazero v1.0.0-pre.2
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 )
 
 require (

--- a/capsule-launcher/go.sum
+++ b/capsule-launcher/go.sum
@@ -68,8 +68,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.2 h1:sHYi8DKUL7s7c4sKz6lw0pNqky5EogYK0Iq4pSIsDog=
-github.com/tetratelabs/wazero v1.0.0-pre.2/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.41.0 h1:zeR0Z1my1wDHTRiamBCXVglQdbUwgb9uWG3k1HQz6jY=

--- a/capsule-launcher/hostfunctions/template.go
+++ b/capsule-launcher/hostfunctions/template.go
@@ -14,14 +14,14 @@ import (
     2- add a reference to this function to `services/wasmrt/wasmrt.go` inside the `CreateWasmRuntime` function
     ```golang
 	// 🏠 Add host functions
-	_, errEnv := wasmRuntime.NewModuleBuilder("env").
-		ExportFunction("hostLogString", hostfunctions.LogString).
-		ExportFunction("hostGetHostInformation", hostfunctions.GetHostInformation).
-		ExportFunction("hostPing", hostfunctions.Ping).
-		ExportFunction("hostHttp", hostfunctions.Http).
-		ExportFunction("hostReadFile", hostfunctions.ReadFile).
-		ExportFunction("hostWriteFile", hostfunctions.WriteFile).
-        ExportFunction("hostFunctionName", hostfunctions.FunctionName). ⬅️
+	_, errEnv := wasmRuntime.NewHostModuleBuilder("env").
+		NewFunctionBuilder().WithFunc(hostfunctions.LogString).Export("hostLogString").
+		NewFunctionBuilder().WithFunc(hostfunctions.GetHostInformation).Export("hostGetHostInformation").
+		NewFunctionBuilder().WithFunc(hostfunctions.Ping).Export("hostPing").
+		NewFunctionBuilder().WithFunc(hostfunctions.Http).Export("hostHttp").
+		NewFunctionBuilder().WithFunc(hostfunctions.ReadFile).Export("hostReadFile").
+		NewFunctionBuilder().WithFunc(hostfunctions.WriteFile).Export("hostWriteFile").
+		NewFunctionBuilder().WithFunc(hostfunctions.FunctionName).Export("hostFunctionName").
 		Instantiate(ctx, wasmRuntime)
     ```
     3- Implement the feature

--- a/capsule-launcher/services/wasmrt/wasmrt.go
+++ b/capsule-launcher/services/wasmrt/wasmrt.go
@@ -23,37 +23,37 @@ func CreateWasmRuntime(ctx context.Context) wazero.Runtime {
 	wasmRuntime := wazero.NewRuntime(ctx)
 	//https://github.com/tetratelabs/wazero/blob/main/examples/allocation/tinygo/greet.go#L29
 
-	// 🏠 Add host functions to the wasmModule (to be availale from the module)
+	// 🏠 Add host functions to the wasmModule (to be available from the module)
 	// These functions allows the module to call functions of the host
 	_, errEnv := wasmRuntime.NewHostModuleBuilder("env").
-		ExportFunction("hostLogString", hostfunctions.LogString).
-		ExportFunction("hostGetHostInformation", hostfunctions.GetHostInformation).
-		ExportFunction("hostPing", hostfunctions.Ping).
-		ExportFunction("hostHttp", hostfunctions.Http).
-		ExportFunction("hostReadFile", hostfunctions.ReadFile).
-		ExportFunction("hostWriteFile", hostfunctions.WriteFile).
-		ExportFunction("hostGetEnv", hostfunctions.GetEnv).
-		ExportFunction("hostRedisSet", hostfunctions.RedisSet).
-		ExportFunction("hostRedisGet", hostfunctions.RedisGet).
-		ExportFunction("hostRedisKeys", hostfunctions.RedisKeys).
-		ExportFunction("hostMemorySet", hostfunctions.MemorySet).
-		ExportFunction("hostMemoryGet", hostfunctions.MemoryGet).
-		ExportFunction("hostMemoryKeys", hostfunctions.MemoryKeys).
-		ExportFunction("hostCouchBaseQuery", hostfunctions.CouchBaseQuery).
-		ExportFunction("hostNatsPublish", hostfunctions.NatsPublish).
-		ExportFunction("hostNatsConnectPublish", hostfunctions.NatsConnectPublish).
-		ExportFunction("hostNatsGetSubject", hostfunctions.NatsGetSubject).
-		ExportFunction("hostNatsGetServer", hostfunctions.NatsGetServer).
-		ExportFunction("hostNatsConnectRequest", hostfunctions.NatsConnectRequest).
-		ExportFunction("hostNatsReply", hostfunctions.NatsReply).
-		ExportFunction("hostMqttGetTopic", hostfunctions.MqttGetTopic).
-		ExportFunction("hostMqttGetServer", hostfunctions.MqttGetServer).
-		ExportFunction("hostMqttGetClientId", hostfunctions.MqttGetClientId).
-		ExportFunction("hostMqttPublish", hostfunctions.MqttPublish).
-		ExportFunction("hostMqttConnectPublish", hostfunctions.MqttConnectPublish).
-		ExportFunction("hostGetExitError", hostfunctions.GetExitError).
-		ExportFunction("hostGetExitCode", hostfunctions.GetExitCode).
-		ExportFunction("hostRequestParamsGet", hostfunctions.RequestParamsGet).
+		NewFunctionBuilder().WithFunc(hostfunctions.LogString).Export("hostLogString").
+		NewFunctionBuilder().WithFunc(hostfunctions.GetHostInformation).Export("hostGetHostInformation").
+		NewFunctionBuilder().WithFunc(hostfunctions.Ping).Export("hostPing").
+		NewFunctionBuilder().WithFunc(hostfunctions.Http).Export("hostHttp").
+		NewFunctionBuilder().WithFunc(hostfunctions.ReadFile).Export("hostReadFile").
+		NewFunctionBuilder().WithFunc(hostfunctions.WriteFile).Export("hostWriteFile").
+		NewFunctionBuilder().WithFunc(hostfunctions.GetEnv).Export("hostGetEnv").
+		NewFunctionBuilder().WithFunc(hostfunctions.RedisSet).Export("hostRedisSet").
+		NewFunctionBuilder().WithFunc(hostfunctions.RedisGet).Export("hostRedisGet").
+		NewFunctionBuilder().WithFunc(hostfunctions.RedisKeys).Export("hostRedisKeys").
+		NewFunctionBuilder().WithFunc(hostfunctions.MemorySet).Export("hostMemorySet").
+		NewFunctionBuilder().WithFunc(hostfunctions.MemoryGet).Export("hostMemoryGet").
+		NewFunctionBuilder().WithFunc(hostfunctions.MemoryKeys).Export("hostMemoryKeys").
+		NewFunctionBuilder().WithFunc(hostfunctions.CouchBaseQuery).Export("hostCouchBaseQuery").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsPublish).Export("hostNatsPublish").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsConnectPublish).Export("hostNatsConnectPublish").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsGetSubject).Export("hostNatsGetSubject").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsGetServer).Export("hostNatsGetServer").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsConnectRequest).Export("hostNatsConnectRequest").
+		NewFunctionBuilder().WithFunc(hostfunctions.NatsReply).Export("hostNatsReply").
+		NewFunctionBuilder().WithFunc(hostfunctions.MqttGetTopic).Export("hostMqttGetTopic").
+		NewFunctionBuilder().WithFunc(hostfunctions.MqttGetServer).Export("hostMqttGetServer").
+		NewFunctionBuilder().WithFunc(hostfunctions.MqttGetClientId).Export("hostMqttGetClientId").
+		NewFunctionBuilder().WithFunc(hostfunctions.MqttPublish).Export("hostMqttPublish").
+		NewFunctionBuilder().WithFunc(hostfunctions.MqttConnectPublish).Export("hostMqttConnectPublish").
+		NewFunctionBuilder().WithFunc(hostfunctions.GetExitError).Export("hostGetExitError").
+		NewFunctionBuilder().WithFunc(hostfunctions.GetExitCode).Export("hostGetExitCode").
+		NewFunctionBuilder().WithFunc(hostfunctions.RequestParamsGet).Export("hostRequestParamsGet").
 		Instantiate(ctx, wasmRuntime)
 
 	if errEnv != nil {

--- a/capsulemodule/hostfunctions/README.md
+++ b/capsulemodule/hostfunctions/README.md
@@ -23,18 +23,18 @@ func Http(ctx context.Context, module api.Module, urlOffset, urlByteCount, metho
 }
 ```
 
-In `services/common/common.go` add the host funtion to the runtime:
+In `services/common/common.go` add the host function to the runtime:
 
 > Example: `common.go`
 
 ```golang
 // 🏠 Add host functions
-_, errEnv := wasmRuntime.NewModuleBuilder("env").
-  ExportFunction("hostLogString", hostfunctions.LogString).
-  ExportFunction("hostGetHostInformation", hostfunctions.GetHostInformation).
-  ExportFunction("hostPing", hostfunctions.Ping).
-  ExportFunction("hostHttp", hostfunctions.Http). 👋👋👋
-  Instantiate(ctx, wasmRuntime)
+_, errEnv := wasmRuntime.NewHostModuleBuilder("env").
+    NewFunctionBuilder().WithFunc(hostfunctions.LogString).Export("hostLogString").
+    NewFunctionBuilder().WithFunc(hostfunctions.GetHostInformation).Export("hostGetHostInformation").
+    NewFunctionBuilder().WithFunc(hostfunctions.Ping).Export("hostPing").
+    NewFunctionBuilder().WithFunc(hostfunctions.Http).Export("hostHttp"). // 👋👋👋
+    Instantiate(ctx, wasmRuntime)
 ```
 
 In `wasmhostfunctions` directory, create a file `function_name.go` (use this package: `package helpers`


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.