### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/capsule-launcher/go.mod
+++ b/capsule-launcher/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.39.0
 	github.com/google/uuid v1.3.0
 	github.com/nats-io/nats.go v1.18.0
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 )
 
 require (

--- a/capsule-launcher/go.sum
+++ b/capsule-launcher/go.sum
@@ -68,8 +68,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.41.0 h1:zeR0Z1my1wDHTRiamBCXVglQdbUwgb9uWG3k1HQz6jY=

--- a/capsule-launcher/hostfunctions/log.go
+++ b/capsule-launcher/hostfunctions/log.go
@@ -1,31 +1,31 @@
 package hostfunctions
 
 import (
-    "context"
-    "fmt"
-    "log"
+	"context"
+	"fmt"
+	"log"
 
-    "github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/api"
 )
 
 // LogString : print a string to the console
 var LogString = api.GoModuleFunc(func(ctx context.Context, module api.Module, stack []uint64) {
 
-    //fmt.Println("🌺", params)
-    //fmt.Println("🖐 position:", stack[0])
-    //fmt.Println("🖐 length:", stack[1])
+	//fmt.Println("🌺", params)
+	//fmt.Println("🖐 position:", stack[0])
+	//fmt.Println("🖐 length:", stack[1])
 
-    position := uint32(stack[0])
-    length := uint32(stack[1])
+	position := uint32(stack[0])
+	length := uint32(stack[1])
 
-    buffer, ok := module.Memory().Read(ctx, position, length)
-    if !ok {
-        log.Panicf("🟥 Memory.Read(%d, %d) out of range", position, length)
-    }
-    //fmt.Println("🍭 ", string(buffer))
-    fmt.Println(string(buffer))
+	buffer, ok := module.Memory().Read(position, length)
+	if !ok {
+		log.Panicf("🟥 Memory.Read(%d, %d) out of range", position, length)
+	}
+	//fmt.Println("🍭 ", string(buffer))
+	fmt.Println(string(buffer))
 
-    stack[0] = 0 // return 0
+	stack[0] = 0 // return 0
 })
 
 /* old version

--- a/capsule-launcher/hostfunctions/memory/memory.go
+++ b/capsule-launcher/hostfunctions/memory/memory.go
@@ -2,8 +2,9 @@ package memory
 
 import (
 	"context"
-	"github.com/tetratelabs/wazero/api"
 	"log"
+
+	"github.com/tetratelabs/wazero/api"
 )
 
 // WriteStringToMemory :
@@ -22,11 +23,11 @@ func WriteStringToMemory(text string, ctx context.Context, module api.Module,
 	}
 
 	retOffset := uint32(results[0])
-	module.Memory().WriteUint32Le(ctx, retBuffPtrPos, retOffset)
-	module.Memory().WriteUint32Le(ctx, retBuffSize, uint32(lengthOfTheMessage))
+	module.Memory().WriteUint32Le(retBuffPtrPos, retOffset)
+	module.Memory().WriteUint32Le(retBuffSize, uint32(lengthOfTheMessage))
 
 	// add the message to the memory of the module
-	module.Memory().Write(ctx, retOffset, []byte(stringMessageFromHost))
+	module.Memory().Write(retOffset, []byte(stringMessageFromHost))
 
 }
 
@@ -34,7 +35,7 @@ func WriteStringToMemory(text string, ctx context.Context, module api.Module,
 // Get string from the module's memory (written by the module)
 // (argument of a function)
 func ReadStringFromMemory(ctx context.Context, module api.Module, contentOffset, contentByteCount uint32) string {
-	contentBuff, ok := module.Memory().Read(ctx, contentOffset, contentByteCount)
+	contentBuff, ok := module.Memory().Read(contentOffset, contentByteCount)
 	if !ok {
 		log.Panicf("🟥 Memory.Read(%d, %d) out of range", contentOffset, contentByteCount)
 	}

--- a/capsule-launcher/services/wasmrt/wasmrt.go
+++ b/capsule-launcher/services/wasmrt/wasmrt.go
@@ -2,9 +2,10 @@ package capsule
 
 import (
 	"context"
+	"log"
+
 	"github.com/bots-garden/capsule/capsule-launcher/hostfunctions"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
-	"log"
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
@@ -342,7 +343,7 @@ func CreateWasmRuntime(ctx context.Context) wazero.Runtime {
 			[]api.ValueType{api.ValueTypeI32}).
 		Export("hostRequestParamsGet")
 
-	_, errBuilder := builder.Instantiate(ctx, wasmRuntime)
+	_, errBuilder := builder.Instantiate(ctx)
 	if errBuilder != nil {
 		log.Panicln("🔴 Error with env module and host function(s):", errBuilder)
 	}

--- a/capsule-launcher/services/wasmrt/wasmrunner.go
+++ b/capsule-launcher/services/wasmrt/wasmrunner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 )
@@ -106,7 +107,7 @@ func ReserveMemorySpaceFor(s string, wm api.Module, ctx context.Context) (pos ui
 	//defer free.Call(ctx, stringParameterPtrPosition)
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !wm.Memory().Write(ctx, uint32(stringParameterPtrPosition), []byte(s)) {
+	if !wm.Memory().Write(uint32(stringParameterPtrPosition), []byte(s)) {
 		//log.Panicf("😡 Memory.Write(%d, %d) out of range of memory size %d", stringParameterPtrPosition, stringParameterLength, wr.Module.Memory().Size(wr.Ctx))
 		return 0, 0, free, errors.New("😡 Memory.Write out of range of memory size")
 	} else {
@@ -132,7 +133,7 @@ func ExecHandleFunction(function api.Function, module api.Module, ctx context.Co
 
 	// The pointer is a linear memory offset,
 	// which is where we write the name.
-	bytes, ok := module.Memory().Read(ctx, handleReturnPtrPos, handleReturnSize)
+	bytes, ok := module.Memory().Read(handleReturnPtrPos, handleReturnSize)
 	if !ok {
 		return nil, errors.New("😡[execHandleFunction] Memory.Read out of range of memory size")
 	}
@@ -158,7 +159,7 @@ func ExecHandleFunctionForHttp(function api.Function, module api.Module, ctx con
 
 	// The pointer is a linear memory offset,
 	// which is where we write the name.
-	bytes, ok := module.Memory().Read(ctx, handleReturnPtrPos, handleReturnSize)
+	bytes, ok := module.Memory().Read(handleReturnPtrPos, handleReturnSize)
 	if !ok {
 		return nil, errors.New("😡[execHandleFunction] Memory.Read out of range of memory size")
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8), which notably:

* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.
* Changes the `Memory` `Read`/`Write` signatures, which no longer
  take a `Context`

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
