### PR TITLE
deps: updates wazero to 1.0.0-rc.2

### DIFF
--- a/capsule-launcher/go.mod
+++ b/capsule-launcher/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.39.0
 	github.com/google/uuid v1.3.0
 	github.com/nats-io/nats.go v1.18.0
-	github.com/tetratelabs/wazero v1.0.0-pre.8
+	github.com/tetratelabs/wazero v1.0.0-rc.2
 )
 
 require (

--- a/capsule-launcher/go.sum
+++ b/capsule-launcher/go.sum
@@ -68,8 +68,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
-github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
+github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.41.0 h1:zeR0Z1my1wDHTRiamBCXVglQdbUwgb9uWG3k1HQz6jY=

--- a/capsule-launcher/services/wasmrt/wasmrt.go
+++ b/capsule-launcher/services/wasmrt/wasmrt.go
@@ -369,7 +369,7 @@ func GetWasmRuntimeAndModuleInstances(wasmFile []byte) (wazero.Runtime, api.Modu
 
 	// 🥚 Instantiate the wasm module (from the wasm file)
 	// 🖐 The main method is called at this moment
-	wasmModule, errInstanceWasmModule := wasmRuntime.InstantiateModuleFromBinary(ctx, wasmFile)
+	wasmModule, errInstanceWasmModule := wasmRuntime.Instantiate(ctx, wasmFile)
 
 	if errInstanceWasmModule != nil {
 		log.Panicln("🔴 Error while creating module instance:", errInstanceWasmModule)
@@ -387,7 +387,7 @@ func GetModuleInstance(wasmFile []byte) (api.Module, context.Context) {
 
 	// 🥚 Instantiate the wasm module (from the wasm file)
 	// 🖐 The main method is called at this moment
-	wasmModule, errInstanceWasmModule := wasmRuntime.InstantiateModuleFromBinary(ctx, wasmFile)
+	wasmModule, errInstanceWasmModule := wasmRuntime.Instantiate(ctx, wasmFile)
 
 	if errInstanceWasmModule != nil {
 		log.Panicln("🔴 Error while creating module instance:", errInstanceWasmModule)


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-rc.2](https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.2). This version does not change any public API, but it delivers several bug fixes and improvements; including
* Full support to the WASI test suite and other third-party integration tests
* Fix for an issue with the context cancellation API
* A number of optimizations to reduce compilation overhead

This PR also includes changes for [wazero](https://wazero.io/) [1.0.0-pre.9][1]. Notably:

* This release includes our last breaking changes before 1.0.0 final:
  * Requires at least Go 1.8
  * Renames `Runtime.InstantiateModuleFromBinary` to `Runtime.Instantiate`
* This release also integrates Go context to limit execution time.
  More details on the [Release Notes][1]

[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
